### PR TITLE
Test: add sad path for non-permitted user attributes

### DIFF
--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -95,6 +95,20 @@ describe "Users API" do
 
         expect(response.status).to eq(400)
       end
+
+      it 'ignores attributes that are not permitted' do
+        user_params = ({
+                  username: 'test1',
+                  email: 'test@email.com',
+                  non_permitted_attribute: 'wooooohoooo'
+                })
+        headers = {"CONTENT_TYPE" => "application/json"}
+        post api_v1_users_path, headers: headers, params: JSON.generate(user: user_params)
+        user = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response.status).to eq(201)
+        expect(user[:data][:attributes]).to_not have_key(:non_permitted_attribute)
+      end
     end
   end
 end


### PR DESCRIPTION
Sad Paths for POST requests to create a new user

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Another sad path

<!-- Please include a summary of the change and which feature/bug fix/etc is implemented here. --> 

<!-- Please list any dependencies that are required for this change here --> 

### Type of change

Please check the relevant option.

- [x] Non-Breaking Change
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Big Breaking change (this breaks everything and I am sorry)

# How Has This Been Tested?

Please check the option(s) that best describe your tests. 

- [ ] New spec files were added
- [x] Tests were added to existing spec files
- [ ] Some tests were changed
- [ ] No tests were changed
- [ ] All tests were changed (please explain what in God's name happened)

### Tests Description

- Please add further details of your tests here.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have removed all unused code or commented why I left it
- [ ] I have deployed my changes to a test-heroku and they work
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
