### PR TITLE
get `/clubs` ENDPOINT

### DIFF
--- a/app/controllers/api/v1/clubs_controller.rb
+++ b/app/controllers/api/v1/clubs_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::ClubsController < ApplicationController
+  def index
+    render json: ClubSerializer.new(Club.all)
+  end
+end

--- a/app/serializers/club_serializer.rb
+++ b/app/serializers/club_serializer.rb
@@ -1,0 +1,6 @@
+class ClubSerializer
+  include JSONAPI::Serializer
+
+  attributes :name, :host_id, :book_id
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/books/search', to: 'books#search'
       resources :books, only: [:index, :show]
-      resources :users
+      resources :users, only: [:index, :show, :create]
+      resources :clubs, only: [:index, :show, :create]
     end
   end
 end

--- a/db/migrate/20220227223321_add_name_to_clubs.rb
+++ b/db/migrate/20220227223321_add_name_to_clubs.rb
@@ -1,0 +1,5 @@
+class AddNameToClubs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :clubs, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_23_211903) do
+ActiveRecord::Schema.define(version: 2022_02_27_223321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2022_02_23_211903) do
     t.integer "book_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
   end
 
   create_table "user_clubs", force: :cascade do |t|

--- a/spec/factories/clubs.rb
+++ b/spec/factories/clubs.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :club do
+    name { Faker::Team.name }
+    host_id { Faker::Number.between(from: 1, to: 500) }
+    book_id { Faker::Number.between(from: 5, to: 8000) }
+  end
+end
+
+def club_with_users(users_count: 3)
+  FactoryBot.create(:club) do |club|
+    FactoryBot.create_list(:user, users_count, clubs: [club])
+  end
+end

--- a/spec/requests/api/v1/books_request_spec.rb
+++ b/spec/requests/api/v1/books_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe "books API" do
 
-  it "it can get book attributes  " do
+  it "it can get book attributes" do
 
     get "/api/v1/books/ZV9DDwAAQBAJ"
 

--- a/spec/requests/api/v1/clubs_request_spec.rb
+++ b/spec/requests/api/v1/clubs_request_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "Clubs API" do
+  describe "index: 'get /clubs'" do
+    describe 'happy path' do
+      it 'returns a json object of all clubs' do
+        user_1 = club_with_users(users_count: 4)
+        user_2 = club_with_users(users_count: 3)
+        user_3 = club_with_users(users_count: 6)
+
+        get api_v1_clubs_path
+
+        expect(response.status).to eq(200)
+        clubs = JSON.parse(response.body, symbolize_names: true)
+
+        expect(clubs).to have_key(:data)
+        expect(clubs[:data].count).to eq(3)
+
+        clubs[:data].each do |club|
+          expect(club[:id]).to be_a String
+          expect(club[:attributes][:name]).to be_a String
+          expect(club[:attributes][:host_id]).to be_an Integer
+          expect(club[:attributes][:book_id]).to be_an Integer
+        end
+      end
+    end
+
+    describe 'sad path' do
+      it 'returns an empty collection when no clubs exist' do
+        get api_v1_clubs_path
+
+        expect(response.status).to eq(200)
+        no_clubs = JSON.parse(response.body, symbolize_names: true)
+
+        expect(Club.count).to eq(0)
+        expect(no_clubs).to have_key(:data)
+        expect(no_clubs[:data]).to eq([])
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -95,6 +95,20 @@ describe "Users API" do
 
         expect(response.status).to eq(400)
       end
+
+      it 'ignores attributes that are not permitted' do
+        user_params = ({
+                  username: 'test1',
+                  email: 'test@email.com',
+                  non_permitted_attribute: 'wooooohoooo'
+                })
+        headers = {"CONTENT_TYPE" => "application/json"}
+        post api_v1_users_path, headers: headers, params: JSON.generate(user: user_params)
+        user = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response.status).to eq(201)
+        expect(user[:data][:attributes]).to_not have_key(:non_permitted_attribute)
+      end
     end
   end
 end


### PR DESCRIPTION
get `/clubs` is now an endpoint that the FE can consume (Clubs API) and call to get all clubs. 
CONSUME: `api/v1/clubs`

Please check the type of change your PR introduces:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

<!-- Please include a summary of the change and which feature/bug fix/etc is implemented here. --> 

<!-- Please list any dependencies that are required for this change here --> 

### Type of change

Please check the relevant option.

- [x] Non-Breaking Change
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Big Breaking change (this breaks everything and I am sorry)

# How Has This Been Tested?

Please check the option(s) that best describe your tests. 

- [x] New spec files were added
- [ ] Tests were added to existing spec files
- [ ] Some tests were changed
- [ ] No tests were changed
- [ ] All tests were changed (please explain what in God's name happened)

### Tests Description

New spec file (`clubs_request_spec`) to handle testing FE calls to the API

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have removed all unused code or commented why I left it
- [ ] I have deployed my changes to a test-heroku and they work
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
